### PR TITLE
Add SIG-Rust

### DIFF
--- a/memberships.nix
+++ b/memberships.nix
@@ -30,4 +30,18 @@ in
       users.raf
     ];
   }
+  {
+    sig = sigs.rust;
+    leaders = with users; [ ];
+    members = with users; [
+      aprl
+      austreelis
+      bbjubjub
+      c8h4
+      eri
+      evanrichter
+      jalil
+      liketechnik
+    ];
+  }
 ]

--- a/shell.nix
+++ b/shell.nix
@@ -1,2 +1,12 @@
-{ mkShellNoCC, python3, ... }:
-mkShellNoCC { packages = [ (python3.withPackages (pyPkgs: [ pyPkgs.pydiscourse ])) ]; }
+{
+  mkShellNoCC,
+  python3,
+  nixfmt-rfc-style,
+  ...
+}:
+mkShellNoCC {
+  packages = [
+    nixfmt-rfc-style
+    (python3.withPackages (pyPkgs: [ pyPkgs.pydiscourse ]))
+  ];
+}

--- a/sigmod.py
+++ b/sigmod.py
@@ -33,7 +33,7 @@ def reconcile_forum_accounts():
     forum_client = pydiscourse.DiscourseClient(api_key=forum_api_key, host=forum_base_url, api_username=forum_api_username)
 
     for sig in sigs:
-        group_name = sig["sig"]["forum"]
+        group_name = sig["sig"]["forum"]["name"]
         group_id = forum_client.group(group_name)["group"]["id"]
 
         should_be = extract_accounts("forum", sig["leaders"], sig["members"])

--- a/sigs.nix
+++ b/sigs.nix
@@ -1,6 +1,9 @@
 {
   documentation = {
-    forum.name = "admins";
+    forum = {
+      name = "sig_documentation";
+      owners = "sig_docs_owners";
+    };
     github = "sig-documentation";
   };
 }

--- a/sigs.nix
+++ b/sigs.nix
@@ -1,6 +1,6 @@
 {
   documentation = {
-    forum = "admins";
+    forum.name = "admins";
     github = "sig-documentation";
   };
 }

--- a/sigs.nix
+++ b/sigs.nix
@@ -6,4 +6,11 @@
     };
     github = "sig-documentation";
   };
+  rust = {
+    forum = {
+      owners = "sig_rs_owners";
+      name = "sig_rust";
+    };
+    github = "sig-rust";
+  };
 }

--- a/users.nix
+++ b/users.nix
@@ -186,4 +186,12 @@
   srestegosaurio = {
     forum = "srestegosaurio";
   };
+  austreelis = {
+    forum = "austreelis";
+    github = "Austreelis";
+  };
+  jalil = {
+    forum = "jalil";
+    github = "jalil-salame";
+  };
 }


### PR DESCRIPTION
Hi!

To get this going a bit more too, I thought I'd start by adding the Rust SIG. 
Since in the forum, there was a split, adding a specialized owners group for each "normal" group, I tried to adjust for that as well - although only minimally in `sigmod.py`. Happy to discuss, of course!

Further, for both SIG-Rust groups, Jake is (obviously) a member too - should that also be reflected here? Or is that handled by Discourse itself through admin-permissions or such?

And the `shell.nix` change is hopefully OK too - I like to extensively rely on dev shells and thus don't have these tools in my `$PATH` all the time :^)