### PR TITLE
feat: Add COMSEC members

### DIFF
--- a/memberships.nix
+++ b/memberships.nix
@@ -1,8 +1,23 @@
 let
+  committees = import ./committees.nix;
   sigs = import ./sigs.nix;
   users = import ./users.nix;
 in
 [
+  {
+    committee = committees.security;
+    leaders = [
+      users.c8h4
+      users.dfh
+      users.jakehamilton
+    ];
+    members = [
+      users.axel
+      users.codingpuffin
+      users.isabel
+      users.minion
+    ];
+  }
   {
     sig = sigs.documentation;
     leaders = [


### PR DESCRIPTION
Some members are missing as they are not yet listed in `users`. Since they might have differing discourse/ github usernames adding the correct information will be left to them.